### PR TITLE
Add default help message

### DIFF
--- a/d3b_dff_cli/cli.py
+++ b/d3b_dff_cli/cli.py
@@ -1,32 +1,55 @@
 import argparse
+import sys
 from .version import __version__
 from .modules.validation.check_manifest import main as check_manifest
 from .modules.validation.check_readgroup import main as check_readgroup
 from .modules.validation.check_url import main as check_url
 from .modules.dewrangle.volume import dewrangle_volume
 
+
 def main():
-    parser = argparse.ArgumentParser(description='A command-line interface for d3b-dff-cli.')
-    subparsers = parser.add_subparsers(title='Available Commands', dest='command')
+    parser = argparse.ArgumentParser(
+        description="A command-line interface for d3b-dff-cli."
+    )
+    subparsers = parser.add_subparsers(title="Available Commands", dest="command")
 
     # Version
-    version_parser = subparsers.add_parser("version", help="Display version information.")
-    version_parser.set_defaults(func=lambda args: print(f"d3b-dff-cli version {__version__}"))
+    version_parser = subparsers.add_parser(
+        "version", help="Display version information."
+    )
+    version_parser.set_defaults(
+        func=lambda args: print(f"d3b-dff-cli version {__version__}")
+    )
 
     # Validation Command
-    validation_parser = subparsers.add_parser('validation', help='Validation commands')
-    validation_subparsers = validation_parser.add_subparsers(title='Validation Subcommands', dest='validation_command')
+    validation_parser = subparsers.add_parser("validation", help="Validation commands")
+    validation_subparsers = validation_parser.add_subparsers(
+        title="Validation Subcommands", dest="validation_command"
+    )
 
     ## validation manifest subcommand
-    manifest_parser = validation_subparsers.add_parser('manifest', help='Manifest validation based on defined rules.')
-    manifest_parser.add_argument('-rules', help='Formatted JSON file defining validation rules.')
-    manifest_parser.add_argument('-rule_type', help='Specific type of validation rule defined in the json rule file.')
-    manifest_parser.add_argument('-manifest_file', help='Manifest based on the d3b genomics manifest template.')
+    manifest_parser = validation_subparsers.add_parser(
+        "manifest", help="Manifest validation based on defined rules."
+    )
+    manifest_parser.add_argument(
+        "-rules", help="Formatted JSON file defining validation rules."
+    )
+    manifest_parser.add_argument(
+        "-rule_type",
+        help="Specific type of validation rule defined in the json rule file.",
+    )
+    manifest_parser.add_argument(
+        "-manifest_file", help="Manifest based on the d3b genomics manifest template."
+    )
     manifest_parser.set_defaults(func=check_manifest)
 
     ## validation read-group subcommand
-    parser_bam = validation_subparsers.add_parser("bam", help="Validator for BAM file @RG based on Samtools.")
-    parser_bam.add_argument("bam_files", nargs="+", help="One or more BAM files to validate #RG")
+    parser_bam = validation_subparsers.add_parser(
+        "bam", help="Validator for BAM file @RG based on Samtools."
+    )
+    parser_bam.add_argument(
+        "bam_files", nargs="+", help="One or more BAM files to validate #RG"
+    )
     parser_bam.set_defaults(func=check_readgroup)
 
     ## validation url subcommand
@@ -35,17 +58,28 @@ def main():
     parser_url.set_defaults(func=check_url)
 
     # Dewrangle Command
-    dewrangle_parser = subparsers.add_parser('dewrangle', help='Dewrangle commands')
-    dewrangle_subparsers = dewrangle_parser.add_subparsers(title='Dewrangle Subcommands', dest='dewrangle_command')
+    dewrangle_parser = subparsers.add_parser("dewrangle", help="Dewrangle commands")
+    dewrangle_subparsers = dewrangle_parser.add_subparsers(
+        title="Dewrangle Subcommands", dest="dewrangle_command"
+    )
     # dewrangle volume subcommand
-    dewrangle_volume_parser = dewrangle_subparsers.add_parser("volume", help="Dewrangle volume")
+    dewrangle_volume_parser = dewrangle_subparsers.add_parser(
+        "volume", help="Dewrangle volume"
+    )
     dewrangle_volume_parser.set_defaults(func=lambda args: dewrangle_volume())
 
     args = parser.parse_args()
+
+    # if no arguments given, print help message
+    if len(sys.argv) == 1:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+
     if hasattr(args, "func"):
         args.func(args)
     else:
         print("Invalid command. Use --help for usage information.")
+
 
 if __name__ == "__main__":
     main()

--- a/d3b_dff_cli/cli.py
+++ b/d3b_dff_cli/cli.py
@@ -78,7 +78,21 @@ def main():
     if hasattr(args, "func"):
         args.func(args)
     else:
-        print("Invalid command. Use --help for usage information.")
+        # something went wrong. Probably a command with no options. Print command's help
+        # retrieve subparsers from parser
+        subparsers_actions = [
+            action
+            for action in parser._actions
+            if isinstance(action, argparse._SubParsersAction)
+        ]
+        # loop through subparser actions and find the command we tried to run
+        for subparsers_action in subparsers_actions:
+            # get all subparsers and print help
+            for choice, subparser in subparsers_action.choices.items():
+                if choice == args.command:
+                    print("Subparser '{}'".format(choice))
+                    print(subparser.format_help())
+                    sys.exit(2)
 
 
 if __name__ == "__main__":

--- a/d3b_dff_cli/cli.py
+++ b/d3b_dff_cli/cli.py
@@ -32,14 +32,17 @@ def main():
         "manifest", help="Manifest validation based on defined rules."
     )
     manifest_parser.add_argument(
-        "-rules", help="Formatted JSON file defining validation rules."
+        "-rules", help="Formatted JSON file defining validation rules.", required=True
     )
     manifest_parser.add_argument(
         "-rule_type",
         help="Specific type of validation rule defined in the json rule file.",
+        required=True,
     )
     manifest_parser.add_argument(
-        "-manifest_file", help="Manifest based on the d3b genomics manifest template."
+        "-manifest_file",
+        help="Manifest based on the d3b genomics manifest template.",
+        required=True,
     )
     manifest_parser.set_defaults(func=check_manifest)
 


### PR DESCRIPTION
# Pull Request Name

- [ ] closes #xxxx
- [ ] README entry added if new functionality
- [ ] fixup commits are appropriately squashed

[Description here]

This PR adds displaying the help message when a command is run with no options. In other words, `d3b validation` and `d3b validation --help` output the same results. However, this doesn't work if a sub command is run without an option. When subcommands (`validation manifest`, etc.) are run, the output message lists what required argument(s) are missing.