### PR TITLE
:truck: use token option when creating client

### DIFF
--- a/d3b_dff_cli/cli.py
+++ b/d3b_dff_cli/cli.py
@@ -105,13 +105,13 @@ def main():
     parser_url.set_defaults(func=check_url)
 
     # Volume Command
-    volume_parser = subparsers.add_parser("volume", help="Dewrangle volume commands")
-    volume_subparsers = volume_parser.add_subparsers(
-        title="Dewrangle Subcommands", dest="volume_command"
+    dewrangle_parser = subparsers.add_parser("dewrangle", help="Dewrangle commands")
+    dewrangle_subparsers = dewrangle_parser.add_subparsers(
+        title="Dewrangle Subcommands", dest="dewrangle_command"
     )
 
     # volume hash subcommand
-    hash_parser = add_hash_arguments(volume_subparsers)
+    hash_parser = add_hash_arguments(dewrangle_subparsers)
 
     args = parser.parse_args()
 

--- a/d3b_dff_cli/modules/dewrangle/volume.py
+++ b/d3b_dff_cli/modules/dewrangle/volume.py
@@ -527,7 +527,15 @@ def get_billing_groups(client, org_id):
     return billing_groups
 
 
-def load_and_hash_volume(bucket_name, study_name, region, prefix=None, billing=None, aws_cred=None, token=None):
+def load_and_hash_volume(
+    bucket_name,
+    study_name,
+    region,
+    prefix=None,
+    billing=None,
+    aws_cred=None,
+    token=None,
+):
     """
     Wrapper function that checks if a volume is loaded, and hashes it.
     Inputs: AWS bucket name, study name, aws region, and optional volume prefix.

--- a/d3b_dff_cli/modules/dewrangle/volume.py
+++ b/d3b_dff_cli/modules/dewrangle/volume.py
@@ -527,14 +527,14 @@ def get_billing_groups(client, org_id):
     return billing_groups
 
 
-def load_and_hash_volume(bucket_name, study_name, region, prefix=None, billing=None, aws_cred=None):
+def load_and_hash_volume(bucket_name, study_name, region, prefix=None, billing=None, aws_cred=None, token=None):
     """
     Wrapper function that checks if a volume is loaded, and hashes it.
     Inputs: AWS bucket name, study name, aws region, and optional volume prefix.
     Output: job id of parent job created when volume is hashed.
     """
 
-    client = create_gql_client()
+    client = create_gql_client(token)
 
     job_id = None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,17 @@
+aiohttp==3.9.3
+aiosignal==1.3.1
+anyio==4.3.0
+async-timeout==4.0.3
+attrs==23.2.0
+backoff==2.2.1
 certifi==2023.11.17
 charset-normalizer==3.3.2
+exceptiongroup==1.2.0
+frozenlist==1.4.1
+gql==3.5.0
+graphql-core==3.2.3
 idna==3.6
+multidict==6.0.5
 numpy==1.24.4
 pandas==2.0.3
 pysam==0.22.0
@@ -8,5 +19,8 @@ python-dateutil==2.8.2
 pytz==2023.3.post1
 requests==2.31.0
 six==1.16.0
+sniffio==1.3.1
+typing_extensions==4.10.0
 tzdata==2023.4
 urllib3==2.1.0
+yarl==1.9.4


### PR DESCRIPTION
# Pull Request Name

- [X] partially closes https://d3b.atlassian.net/browse/D3B-192
- [ ] README entry added if new functionality
- [ ] fixup commits are appropriately squashed

[Description here]

This PR uses the api_key option in `create_gql_client` function. It also updates the `requirements.txt`. Super tiny PR, but this is the first structural step away from the dewrangle api repo I'm migrating from.