### PR TITLE
:sparkles: add function to add comment to a Jira ticket

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,8 @@ To access Dewrangle, you must sign in to [Dewrangle](dewrangle.com) and generate
 ```bash
 [default]
   api_key = "<your token string>"
+```
+
+### Jira
+
+This isn't included as an option on the command line, and is only available as importable functions. The main function is `add_jira_comment` which adds a provided message as a comment to the provided ticket.

--- a/README.md
+++ b/README.md
@@ -91,3 +91,6 @@ To access Dewrangle, you must sign in to [Dewrangle](dewrangle.com) and generate
 ### Jira
 
 This isn't included as an option on the command line, and is only available as importable functions. The main function is `add_jira_comment` which adds a provided message as a comment to the provided ticket.
+
+
+This functionality was added here so that it can be used in the lambdas that are being used by the [Data Transfer step function](https://github.com/d3b-center/d3b-dff-data-transfer-pipeline). It was decided that each step in the step function will add a comment to the data transfer Jira ticket to track the status of the step function. For futher information, please see https://d3b.atlassian.net/browse/D3B-595.

--- a/d3b_dff_cli/modules/jira/add_comment.py
+++ b/d3b_dff_cli/modules/jira/add_comment.py
@@ -1,0 +1,76 @@
+"""Add comment to Jira ticket"""
+import json
+import urllib3
+import logging
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def check_status(response):
+    """
+    Check response status and handle appropriately
+    """
+
+    # check that response is successful
+    if response.status in [201, 204]:
+        logger.info("Jira ticket updated successfully")
+    elif response.status == 200:
+        logger.info("Get request successful")
+    else:
+        logger.error(
+            f"Failed to update Jira ticket: {response.status} - {response.data}"
+        )
+    
+    return
+
+
+def add_jira_comment(auth, jira_url, message, ticket_id):
+    """
+    Update Jira ticket with message and set status
+
+    Parameters:
+    auth (str): Base64 encoded Jira username and password
+    jira_url (str): Jira URL
+    message (str): Comment to add to Jira ticket
+    ticket_id (str): Jira ticket ID
+    """
+
+    http = urllib3.PoolManager()
+
+    def check_status(response):
+        """
+        Check status code of response
+        """
+        if response.status != 201:
+            print(f"Error: {response.status} - {response.data}")
+            exit(1)
+
+        return response.status
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Basic {auth}",
+    }
+
+    url = f"{jira_url}/rest/api/3/issue/{ticket_id}/comment"
+
+    payload = json.dumps(
+        {
+            "body": {
+                "content": [
+                    {
+                        "content": [{"text": f"{message}", "type": "text"}],
+                        "type": "paragraph",
+                    }
+                ],
+                "type": "doc",
+                "version": 1,
+            }
+        }
+    ).encode("utf-8")
+
+    response = http.request("POST", url, body=payload, headers=headers)
+
+    check_status(response)
+
+    return

--- a/docs/adr/0001-add-jira-commands-to-repo.md
+++ b/docs/adr/0001-add-jira-commands-to-repo.md
@@ -1,0 +1,21 @@
+# 1. Add Jira Commands to D3B DFF ClI Repo
+
+## Status
+
+Partially Implemented
+
+## Context
+
+This repository contains the DFF CLI that is being developed as a cli and as a set of Python modules that can be imported within other scripts. The [Data Transfer step function](https://github.com/d3b-center/d3b-dff-data-transfer-pipeline) imports the validation and Dewrangle functions within most steps of that pipeline. We want to update the data transfer step function to add a comment on a Jira ticket when most steps of the pipeline are finished and when errors occur in the pipeline.
+
+The Data Transfer pipeline uses [notification lambas]() that send Slack messages, adds Jira comments, and sets the Jira status of tickets while the pipeline runs. But, those lambdas are only triggered when a new file is created in a manifest bucket or when the step function changes status ("RUNNING", "SUCCEDED", or "FAILED"). When a step function progresses from one step to another, the status is not changed so the status notification lambda can't be used to send alerts when a step finishes. The repo with the notification lambdas is private, so it can't be included in the Dockerfiles of the step function lambdas.
+
+The notification lambdas are only Python scripts not Docker images and so can't have additional libraries installed.
+
+## Decision
+
+Copy the add_jira_comment and check_status functions into the D3B DFF CLI so the Data Transfer step function can create Jira comments recording step function progress. The functions are currently not added to the cli because there are no existing plans to use them as such.
+
+## Consequences
+
+The same or very simliar versions of some Jira functions exist and need to be maintained in two separate repos. One here and another copy in the notification lambdas repo.


### PR DESCRIPTION
# Pull Request Name

- [X] supports https://d3b.atlassian.net/browse/D3B-595
- [X] README entry added if new functionality
- [ ] fixup commits are appropriately squashed

[Description here]

This PR adds a function to add a comment to a Jira ticket. This will be used within the data transfer step function so that each step of the step function can add a comment that the step has finished. I added this here because most if not all of the lambdas in the step function are already importing the cli. I didn't add an option to call this function from the cli because I don't think we need it yet.