### PR TITLE
:bug: fix validation: file_size

### DIFF
--- a/d3b_dff_cli/modules/validation/check_manifest.py
+++ b/d3b_dff_cli/modules/validation/check_manifest.py
@@ -68,7 +68,7 @@ def validate_row(row, rules):
                                     error_messages.append(f"Warning: *{col}* less than {greater_than_value}")
 
                             except ValueError:
-                                error_messages.append(f"*{col}*: {fize_size_str} is not a valid numeric value")
+                                error_messages.append(f"*{col}*: {fize_size_str} is not a valid value")
 
     if error_messages:
         return False, error_messages  # Return all error messages for this row

--- a/d3b_dff_cli/modules/validation/check_manifest.py
+++ b/d3b_dff_cli/modules/validation/check_manifest.py
@@ -43,21 +43,20 @@ def validate_row(row, rules):
                 
                 # Check if file_format is "FASTQ," "BAM," or "CRAM" and file_size > specified value
                 if col == "file_size" and row.get("file_format", "").lower() in ["fastq", "bam", "cram"]:
-                    greater_than_value = consequence.get("greater_than")
-                    if greater_than_value:
+                    general_cutoff = consequence.get("general_byte_cutoff")
+                    wgs_wxs_cutoff = consequence.get("wgs_wxs_byte_cutoff")
+                    if general_cutoff:
                         experiment = row.get("experiment_strategy", "").lower()
                         if experiment in ["wgs", "wxs", "wes"]:
-                            greater_than_value = "1 GB"
-                            minum_value = 1_000_000_000 # WGS/WXS should be greater than 1G
+                            minum_value = float(wgs_wxs_cutoff)
                         else:
-                            greater_than_value = consequence.get("greater_than")
-                            minum_value = float(greater_than_value.rstrip("M"))*1000_000 # Other experimental strategy should be greater than the specified value.
-                        
+                            minum_value = float(general_cutoff)
+
                         if pd.notna(cell_value):
                             try:
                                 size_byte = float(cell_value)
                                 if size_byte < minum_value:
-                                    error_messages.append(f"Warning: *{col}* less than {greater_than_value}")
+                                    error_messages.append(f"Warning: *{col}* less than {minum_value}")
 
                             except ValueError:
                                 error_messages.append(f"*{col}*: {cell_value} is not a valid value")

--- a/d3b_dff_cli/modules/validation/check_manifest.py
+++ b/d3b_dff_cli/modules/validation/check_manifest.py
@@ -54,13 +54,13 @@ def validate_row(row, rules):
                             minum_value = float(greater_than_value.rstrip("M"))*1000_000 # Other experimental strategy should be greater than the specified value.
                         
                         if pd.notna(cell_value):
-                            size_byte = float(cell_value)
                             try:
+                                size_byte = float(cell_value)
                                 if size_byte < minum_value:
                                     error_messages.append(f"Warning: *{col}* less than {greater_than_value}")
 
                             except ValueError:
-                                error_messages.append(f"*{col}*: {size_byte} is not a valid value")
+                                error_messages.append(f"*{col}*: {cell_value} is not a valid value")
 
     if error_messages:
         return False, error_messages  # Return all error messages for this row

--- a/d3b_dff_cli/modules/validation/check_manifest.py
+++ b/d3b_dff_cli/modules/validation/check_manifest.py
@@ -54,21 +54,13 @@ def validate_row(row, rules):
                             minum_value = float(greater_than_value.rstrip("M"))*1000_000 # Other experimental strategy should be greater than the specified value.
                         
                         if pd.notna(cell_value):
-                            fize_size_str = str(cell_value).lower()
-
-                            # support file size formats in bytes, megabytes, and gigabytes: 100, 100M, 100MB, 10G, 10GB
+                            size_byte = float(cell_value)
                             try:
-                                if 'm' in fize_size_str:
-                                    size_byte = float(re.sub('[^0-9.]', '', fize_size_str)) * 1_000_000
-                                elif 'g' in fize_size_str:
-                                    size_byte = float(re.sub('[^0-9.]', '', fize_size_str)) * 1_000_000_000
-                                else:
-                                    size_byte = float(fize_size_str)
                                 if size_byte < minum_value:
                                     error_messages.append(f"Warning: *{col}* less than {greater_than_value}")
 
                             except ValueError:
-                                error_messages.append(f"*{col}*: {fize_size_str} is not a valid value")
+                                error_messages.append(f"*{col}*: {size_byte} is not a valid value")
 
     if error_messages:
         return False, error_messages  # Return all error messages for this row

--- a/data/example_manifest.csv
+++ b/data/example_manifest.csv
@@ -1,3 +1,3 @@
 sample_id,aliquot_id,tissue_type,file_name,file_format,file_size,file_hash_type,file_hash_value,sequencing_center,platform,instrument_model,experiment_strategy,library_selection,library_strand,target_capture_kit_name,target_capture_kit_link,is_paired_end,read_pair_number,flow_cell_barcode,lane_number,is_adapter_trimmed,adapter_sequencing,total_reads,mean_coverage,reference_genome
-test1,1549608,Tumor,test1.fq.gz,FASTQ,30000000000,md5,284799447,Broad,complete genomics,Illumina HiSeq X Ten,wxs,Hybrid Selection,Not Applicable,,,TRUE,R1,H0164ALXX140820,1,FALSE,AGATCGGAAGAGC,1000000,30X,
+test1,1549608,Tumor,test1.fq.gz,FASTQ,300M,md5,284799447,Broad,complete genomics,Illumina HiSeq X Ten,wxs,Hybrid Selection,Not Applicable,,,TRUE,R1,H0164ALXX140820,1,FALSE,AGATCGGAAGAGC,1000000,30X,
 test2,15480,Tumor,test2.bam,BAM,1100000001,md5,284799447,Broad,complete genomics,Illumina HiSeq X Ten,wxs,Hybrid Selection,Not Applicable,,,TRUE,R1,,,TRUE,,1000000,30X,

--- a/data/example_manifest.csv
+++ b/data/example_manifest.csv
@@ -1,3 +1,3 @@
 sample_id,aliquot_id,tissue_type,file_name,file_format,file_size,file_hash_type,file_hash_value,sequencing_center,platform,instrument_model,experiment_strategy,library_selection,library_strand,target_capture_kit_name,target_capture_kit_link,is_paired_end,read_pair_number,flow_cell_barcode,lane_number,is_adapter_trimmed,adapter_sequencing,total_reads,mean_coverage,reference_genome
-test1,1549608,Tumor,test1.fq.gz,FASTQ,300M,md5,284799447,Broad,complete genomics,Illumina HiSeq X Ten,wxs,Hybrid Selection,Not Applicable,,,TRUE,R1,H0164ALXX140820,1,FALSE,AGATCGGAAGAGC,1000000,30X,
+test1,1549608,Tumor,test1.fq.gz,FASTQ,30000000000,md5,284799447,Broad,complete genomics,Illumina HiSeq X Ten,wxs,Hybrid Selection,Not Applicable,,,TRUE,R1,H0164ALXX140820,1,FALSE,AGATCGGAAGAGC,1000000,30X,
 test2,15480,Tumor,test2.bam,BAM,1100000001,md5,284799447,Broad,complete genomics,Illumina HiSeq X Ten,wxs,Hybrid Selection,Not Applicable,,,TRUE,R1,,,TRUE,,1000000,30X,

--- a/data/validation_rules.json
+++ b/data/validation_rules.json
@@ -125,7 +125,7 @@
       "consequences": [
         {
           "column": "file_size",
-          "greater_than": "1 GB",
+          "greater_than": "200M",
           "valid": true
         }
       ]
@@ -377,7 +377,7 @@
       "consequences": [
         {
           "column": "file_size",
-          "greater_than": "1 GB",
+          "greater_than": "200M",
           "valid": true
         }
       ]

--- a/data/validation_rules.json
+++ b/data/validation_rules.json
@@ -380,8 +380,9 @@
       "consequences": [
         {
           "column": "file_size",
-          "general_byte_cutoff": "200,000,000",
-          "wgs_wxs_byte_cutoff": "1,000,000,000",
+          "_comment": "The threshold for WGS/WXS is 1GB, and 200MB for others.",
+          "general_byte_cutoff": "200000000",
+          "wgs_wxs_byte_cutoff": "1000000000",
           "valid": true
         }
       ]

--- a/data/validation_rules.json
+++ b/data/validation_rules.json
@@ -125,8 +125,11 @@
       "consequences": [
         {
           "column": "file_size",
-          "greater_than": "200M",
+          "_comment": "The threshold for WGS/WXS is 1GB, and 200MB for others.",
+          "general_byte_cutoff": "200000000",
+          "wgs_wxs_byte_cutoff": "1000000000",
           "valid": true
+
         }
       ]
     }
@@ -377,7 +380,8 @@
       "consequences": [
         {
           "column": "file_size",
-          "greater_than": "200M",
+          "general_byte_cutoff": "200,000,000",
+          "wgs_wxs_byte_cutoff": "1,000,000,000",
           "valid": true
         }
       ]


### PR DESCRIPTION
# Fix validation file_size issues
**Related tickets**
- [D3B-783](https://d3b.atlassian.net/browse/D3B-783)
- [D3B-785](https://d3b.atlassian.net/browse/D3B-785)
- [D3B-786](https://d3b.atlassian.net/browse/D3B-786)
- [D3B-787](https://d3b.atlassian.net/browse/D3B-787)

### Updates description
1. fix bug: files without file size pass validation
2. use "metric" MB/GB for file size calculation
    - 1MB = 100,000 Bytes
    - 1GB = 1,000,000,000 Bytes
3. update minimum file size cutoff
    - WGS/WXS: 1GB
         - for example: the file_size of this wxs cram is 2G: `s3://d3b-study-us-east-1-prd-sd-z7r9svga/pnoc022/source/PMLBM000ESR_PMCRZ389QWO_WXS.cram`
    - Other sequencing experiment: 200M
5. support input file size formats in bytes, megabytes, and gigabytes: 
    example acceptable file size values:
    - 100
    - 100M
    - 100MB
    - 10G
    - 10GB 

[D3B-783]: https://d3b.atlassian.net/browse/D3B-783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[D3B-785]: https://d3b.atlassian.net/browse/D3B-785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[D3B-786]: https://d3b.atlassian.net/browse/D3B-786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[D3B-787]: https://d3b.atlassian.net/browse/D3B-787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ